### PR TITLE
Restore conversion history and prepare 1.0.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -86,10 +86,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Build frontend
         run: npm run build
 
+      - name: Run frontend tests
+        run: npm run test:frontend
+
       - name: Run LibreOffice WASM smoke tests
         run: npm run test:libreoffice
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,7 +1155,7 @@ dependencies = [
 
 [[package]]
 name = "file-converter-desktop"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ and local workers without permitting remote network destinations.
 ```sh
 cargo test --workspace
 npm run build
+npm run test:frontend
 npm run test:libreoffice
 cargo clippy --workspace --all-targets -- -D warnings
 ```
@@ -114,6 +115,8 @@ cargo clippy --workspace --all-targets -- -D warnings
 Rust tests cover detection, registry uniqueness, routing, safe filenames,
 metadata-only migration behavior, image conversion, PDF passthrough, failed
 history, missing-source reconversion, and legacy BLOB compatibility.
+Frontend tests cover non-reentrant conversion state so history actions cannot
+replace or clear a conversion that is already running.
 
 `npm run test:libreoffice` is the heavier local smoke suite. It initializes the
 same bundled LibreOffice WASM binary and converts generated DOCX, PPTX, XLSX,

--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ location.
 
 Legacy `output_data` and `output_base64` columns remain readable so older output
 copies can still be restored. New conversions never populate them. If a new
-output disappears, the UI offers **Reconvert** when its original source path
-still exists; otherwise it reports the file as unavailable.
+output disappears, the **History** dialog offers **Reconvert** when its original
+source path still exists. Legacy entries with stored PDF data can be restored;
+otherwise the dialog reports that the output is unavailable. Existing PDFs can
+also be opened and history entries can be deleted from the same dialog.
 
 Each job gets a dedicated application-cache work directory. The original is
 never modified. Job artifacts are removed after success, failure, or

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   </head>
   <body>
     <div id="header">
+      <button id="history-button" type="button">History</button>
       <button id="settings-button" type="button">Settings</button>
     </div>
 
@@ -46,6 +47,17 @@
           <button type="button" data-close="settings-dialog">Close</button>
         </div>
       </form>
+    </dialog>
+
+    <dialog id="history-dialog">
+      <section id="history-panel">
+        <h3>Conversion history</h3>
+        <p id="history-summary">Your recent local conversions.</p>
+        <div id="history-list" aria-live="polite"></div>
+        <div class="dialog-actions">
+          <button type="button" data-close="history-dialog">Close</button>
+        </div>
+      </section>
     </dialog>
 
     <script type="module" src="/src/main.js"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "file-converter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "file-converter",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@matbee/libreoffice-converter": "2.7.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "file-converter",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "vite --port 1420",
     "prebuild": "npm run prepare:libreoffice",
     "build": "vite build",
+    "test:frontend": "node --test tests/*.test.mjs",
     "test:libreoffice": "node scripts/verify-libreoffice.mjs",
     "tauri": "tauri"
   },

--- a/scripts/verify-libreoffice.mjs
+++ b/scripts/verify-libreoffice.mjs
@@ -1,34 +1,71 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { basename, extname, join } from "node:path";
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { extname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createWorkerConverter } from "@matbee/libreoffice-converter/server";
 
 const root = fileURLToPath(new URL("..", import.meta.url));
+const scriptPath = fileURLToPath(import.meta.url);
 const fixtures = ["sample.docx", "sample.pptx", "sample.xlsx", "sample.odt", "sample.rtf", "sample.txt"];
-const outputDirectory = await mkdtemp(join(tmpdir(), "file-converter-wasm-"));
+const fixtureFlag = process.argv.indexOf("--fixture");
 
-try {
-  for (const fixture of fixtures) {
-    // A fresh worker keeps a failure in one LibreOffice document family from
-    // contaminating later smoke cases. The packaged app still reuses its
-    // browser worker; this process-isolated suite verifies each format.
-    const converter = await createWorkerConverter();
-    try {
-      const input = await readFile(join(root, "tests", "fixtures", fixture));
-      const result = await converter.convert(input, {
-        inputFormat: extname(fixture).slice(1),
-        outputFormat: "pdf",
-      }, fixture);
-      if (result.data.length < 5 || Buffer.from(result.data.subarray(0, 5)).toString() !== "%PDF-") {
-        throw new Error(`${fixture} did not produce a PDF`);
-      }
-      await writeFile(join(outputDirectory, `${basename(fixture, extname(fixture))}.pdf`), result.data);
-      console.log(`${fixture} -> PDF (${result.data.length} bytes)`);
-    } finally {
-      await converter.destroy();
-    }
+if (fixtureFlag >= 0) {
+  const fixture = process.argv[fixtureFlag + 1];
+  if (!fixtures.includes(fixture)) {
+    throw new Error(`Unknown LibreOffice fixture: ${fixture || "(missing)"}`);
   }
-} finally {
-  await rm(outputDirectory, { recursive: true, force: true });
+  await convertFixture(fixture);
+} else {
+  for (const fixture of fixtures) {
+    await runIsolatedFixture(fixture);
+  }
+}
+
+async function convertFixture(fixture) {
+  const converter = await createWorkerConverter();
+  try {
+    const input = await readFile(join(root, "tests", "fixtures", fixture));
+    const result = await converter.convert(input, {
+      inputFormat: extname(fixture).slice(1),
+      outputFormat: "pdf",
+    }, fixture);
+    if (result.data.length < 5 || Buffer.from(result.data.subarray(0, 5)).toString() !== "%PDF-") {
+      throw new Error(`${fixture} did not produce a PDF`);
+    }
+    console.log(`${fixture} -> PDF (${result.data.length} bytes)`);
+  } finally {
+    await converter.destroy();
+  }
+}
+
+function runIsolatedFixture(fixture) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [scriptPath, "--fixture", fixture], {
+      stdio: "inherit",
+    });
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGKILL");
+      reject(new Error(`${fixture} exceeded the 90-second LibreOffice smoke-test limit`));
+    }, 90_000);
+
+    child.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.once("exit", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${fixture} smoke test exited with ${signal || `code ${code}`}`));
+      }
+    });
+  });
 }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "file-converter-desktop"
-version = "1.0.0"
+version = "1.0.1"
 description = "A local, offline-first desktop file converter"
 license = "Apache-2.0"
 edition = "2021"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -201,12 +201,7 @@ pub(crate) fn restore_conversion(
 
 #[tauri::command]
 pub(crate) fn delete_conversion(state: State<'_, AppState>, id: Uuid) -> Result<(), String> {
-    if let Some(path) = state
-        .service
-        .database()
-        .delete_conversion(id)
-        .map_err(error_message)?
-    {
+    if let Some(path) = state.service.delete_history(id).map_err(error_message)? {
         match std::fs::remove_file(&path) {
             Ok(()) => {}
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -9,7 +9,7 @@ use crate::{
     conversion::{
         detect_format, supported_formats, unique_output_path, ConversionStart, SupportedFormat,
     },
-    database::Conversion,
+    database::{Conversion, Database},
     AppState,
 };
 
@@ -28,6 +28,15 @@ pub(crate) struct OpenConversionResult {
     missing: bool,
     restorable: bool,
     reconvertible: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct HistoryEntry {
+    #[serde(flatten)]
+    conversion: Conversion,
+    #[serde(flatten)]
+    availability: OpenConversionResult,
 }
 
 #[tauri::command]
@@ -54,12 +63,14 @@ pub(crate) fn inspect_source(input_path: String) -> Result<DetectedSource, Strin
 }
 
 #[tauri::command]
-pub(crate) fn list_conversions(state: State<'_, AppState>) -> Result<Vec<Conversion>, String> {
-    state
-        .service
-        .database()
+pub(crate) fn list_conversions(state: State<'_, AppState>) -> Result<Vec<HistoryEntry>, String> {
+    let database = state.service.database();
+    database
         .list_conversions()
-        .map_err(error_message)
+        .map_err(error_message)?
+        .into_iter()
+        .map(|conversion| history_entry(database, conversion))
+        .collect()
 }
 
 #[tauri::command]
@@ -135,36 +146,18 @@ pub(crate) fn open_conversion(
         .database()
         .get_conversion(id)
         .map_err(error_message)?;
+    let availability = conversion_availability(state.service.database(), &conversion)?;
+    if availability.missing {
+        return Ok(availability);
+    }
     let path = conversion
         .output_path
         .as_deref()
         .ok_or_else(|| "This conversion does not have an output file.".to_string())?;
-    match std::fs::metadata(path) {
-        Ok(metadata) if metadata.is_file() => {
-            app.opener()
-                .open_path(path, None::<&str>)
-                .map_err(error_message)?;
-            Ok(OpenConversionResult {
-                missing: false,
-                restorable: false,
-                reconvertible: false,
-            })
-        }
-        Ok(_) => Err("The saved output path is not a file.".to_string()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(OpenConversionResult {
-            missing: true,
-            restorable: state
-                .service
-                .database()
-                .has_stored_file(id)
-                .map_err(error_message)?,
-            reconvertible: conversion
-                .source_path
-                .as_deref()
-                .is_some_and(|source| Path::new(source).is_file()),
-        }),
-        Err(error) => Err(format!("Could not check the converted file: {error}")),
-    }
+    app.opener()
+        .open_path(path, None::<&str>)
+        .map_err(error_message)?;
+    Ok(availability)
 }
 
 #[tauri::command]
@@ -237,6 +230,85 @@ fn conversion_id_header(request: &tauri::ipc::Request<'_>) -> Result<Uuid, Strin
     Uuid::parse_str(value).map_err(|_| "The conversion ID is invalid.".to_string())
 }
 
+fn history_entry(database: &Database, conversion: Conversion) -> Result<HistoryEntry, String> {
+    let availability = conversion_availability(database, &conversion)?;
+    Ok(HistoryEntry {
+        conversion,
+        availability,
+    })
+}
+
+fn conversion_availability(
+    database: &Database,
+    conversion: &Conversion,
+) -> Result<OpenConversionResult, String> {
+    let missing = conversion
+        .output_path
+        .as_deref()
+        .map(Path::new)
+        .is_none_or(|path| !path.is_file());
+    Ok(OpenConversionResult {
+        missing,
+        restorable: missing
+            && database
+                .has_stored_file(conversion.id)
+                .map_err(error_message)?,
+        reconvertible: missing
+            && conversion
+                .source_path
+                .as_deref()
+                .is_some_and(|source| Path::new(source).is_file()),
+    })
+}
+
 fn error_message(error: impl std::fmt::Display) -> String {
     error.to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::database::NewConversion;
+
+    #[test]
+    fn history_availability_tracks_missing_outputs_and_sources() {
+        let directory = tempfile::tempdir().unwrap();
+        let source_path = directory.path().join("source.docx");
+        let output_path = directory.path().join("source.pdf");
+        std::fs::write(&source_path, b"source").unwrap();
+        std::fs::write(&output_path, b"%PDF-output").unwrap();
+
+        let database = Database::open(&directory.path().join("history.sqlite3")).unwrap();
+        let id = Uuid::new_v4();
+        database
+            .insert_conversion(NewConversion {
+                id,
+                source_name: "source.docx",
+                source_path: &source_path,
+                detected_format: "docx",
+                output_format: "pdf",
+                engine: "libreoffice-wasm",
+                source_size: 6,
+            })
+            .unwrap();
+        let conversion = database
+            .mark_finished(id, &output_path, "libreoffice-wasm", 11)
+            .unwrap();
+
+        let available = conversion_availability(&database, &conversion).unwrap();
+        assert!(!available.missing);
+        assert!(!available.restorable);
+        assert!(!available.reconvertible);
+
+        std::fs::remove_file(&output_path).unwrap();
+        let missing = conversion_availability(&database, &conversion).unwrap();
+        assert!(missing.missing);
+        assert!(!missing.restorable);
+        assert!(missing.reconvertible);
+
+        std::fs::remove_file(&source_path).unwrap();
+        let unavailable = conversion_availability(&database, &conversion).unwrap();
+        assert!(unavailable.missing);
+        assert!(!unavailable.reconvertible);
+    }
 }

--- a/src-tauri/src/conversion/service.rs
+++ b/src-tauri/src/conversion/service.rs
@@ -351,6 +351,25 @@ impl ConversionService {
             .map_err(|error| ConversionError::Persistence(error.to_string()))
     }
 
+    pub fn delete_history(&self, id: Uuid) -> Result<Option<String>, ConversionError> {
+        if self
+            .pending_wasm
+            .lock()
+            .map_err(|_| {
+                ConversionError::ConversionFailed("conversion queue lock was poisoned".into())
+            })?
+            .contains_key(&id)
+        {
+            return Err(ConversionError::ConversionFailed(
+                "Active conversions cannot be deleted. Cancel or finish the conversion first."
+                    .into(),
+            ));
+        }
+        self.database
+            .delete_conversion(id)
+            .map_err(|error| ConversionError::Persistence(error.to_string()))
+    }
+
     fn take_pending(&self, id: Uuid) -> Result<ConversionRequest, ConversionError> {
         self.pending_wasm
             .lock()
@@ -512,6 +531,33 @@ mod tests {
         assert_eq!(cancelled.status, "cancelled");
         assert!(service
             .complete_wasm(task.conversion_id, b"%PDF-1.7\nstale")
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn active_wasm_conversion_cannot_be_deleted() {
+        let directory = tempfile::tempdir().unwrap();
+        let database = Arc::new(Database::open(&directory.path().join("db.sqlite3")).unwrap());
+        let service = ConversionService::new(database, directory.path().join("work"));
+        let source = directory.path().join("notes.txt");
+        std::fs::write(&source, b"local fixture").unwrap();
+        let task = service.start(source).await.unwrap().wasm_task.unwrap();
+
+        assert!(service.delete_history(task.conversion_id).is_err());
+        assert_eq!(
+            service
+                .database()
+                .get_conversion(task.conversion_id)
+                .unwrap()
+                .status,
+            "processing"
+        );
+
+        service.cancel(task.conversion_id).unwrap();
+        assert!(service.delete_history(task.conversion_id).is_ok());
+        assert!(service
+            .database()
+            .get_conversion(task.conversion_id)
             .is_err());
     }
 

--- a/src-tauri/src/database.rs
+++ b/src-tauri/src/database.rs
@@ -286,15 +286,21 @@ impl Database {
 
     pub fn delete_conversion(&self, id: Uuid) -> Result<Option<String>> {
         let connection = self.lock()?;
-        let path: Option<Option<String>> = connection
+        let conversion: Option<(String, Option<String>)> = connection
             .query_row(
-                "SELECT output_path FROM conversions WHERE id = ?1",
+                "SELECT status, output_path FROM conversions WHERE id = ?1",
                 [id.to_string()],
-                |row| row.get(0),
+                |row| Ok((row.get(0)?, row.get(1)?)),
             )
             .optional()?;
+        let (status, path) = conversion.context("Conversion was not found.")?;
+        if !matches!(status.as_str(), "finished" | "failed" | "cancelled") {
+            anyhow::bail!(
+                "Active conversions cannot be deleted. Cancel or finish the conversion first."
+            );
+        }
         connection.execute("DELETE FROM conversions WHERE id = ?1", [id.to_string()])?;
-        Ok(path.flatten())
+        Ok(path)
     }
 
     fn lock(&self) -> Result<std::sync::MutexGuard<'_, Connection>> {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "File Converter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "identifier": "us.thecalhouns.file-converter",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src/conversion-guard.js
+++ b/src/conversion-guard.js
@@ -1,0 +1,19 @@
+export class ConversionGuard {
+  #activeToken = null;
+
+  get isActive() {
+    return this.#activeToken !== null;
+  }
+
+  begin() {
+    if (this.#activeToken !== null) return null;
+    this.#activeToken = Symbol("conversion");
+    return this.#activeToken;
+  }
+
+  finish(token) {
+    if (token !== this.#activeToken) return false;
+    this.#activeToken = null;
+    return true;
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -6,13 +6,15 @@ const state = {
   selectedPath: null,
   detected: null,
   supportedFormats: [],
+  conversions: [],
   activeConversionId: null,
   cancellationRequested: false,
 };
 
 const elements = Object.fromEntries([
-  "settings-button", "choose-file", "selected-file", "convert", "convert-button", "status",
-  "status-message", "settings-dialog", "supported-list",
+  "history-button", "settings-button", "choose-file", "selected-file", "convert", "convert-button",
+  "status", "status-message", "history-dialog", "history-summary", "history-list", "settings-dialog",
+  "supported-list",
 ].map((id) => [camelize(id), document.querySelector(`#${id}`)]));
 
 class LibreOfficeWasmRunner {
@@ -65,6 +67,11 @@ elements.convert.addEventListener("submit", async (event) => {
   await beginConversion(() => invoke("start_conversion", { inputPath: state.selectedPath }));
 });
 elements.settingsButton.addEventListener("click", () => elements.settingsDialog.showModal());
+elements.historyButton.addEventListener("click", async () => {
+  await loadHistory();
+  elements.historyDialog.showModal();
+});
+elements.historyList.addEventListener("click", handleHistoryAction);
 
 document.querySelectorAll("[data-close]").forEach((button) => {
   button.addEventListener("click", () => document.querySelector(`#${button.dataset.close}`).close());
@@ -134,6 +141,7 @@ async function beginConversion(createStart) {
     state.activeConversionId = null;
     state.cancellationRequested = false;
     setBusy(false);
+    await loadHistory();
   }
 }
 
@@ -185,6 +193,130 @@ async function loadSupportedFormats() {
       <p>${formats.map((format) => `<span title="${escapeHtml(format.label)}">.${escapeHtml(format.extensions.join(" / ."))}</span>`).join("")}</p>
     </section>
   `).join("");
+}
+
+async function loadHistory() {
+  elements.historyList.setAttribute("aria-busy", "true");
+  try {
+    state.conversions = await invoke("list_conversions");
+    renderHistory();
+  } catch (error) {
+    elements.historySummary.textContent = "History is temporarily unavailable.";
+    elements.historyList.innerHTML = `<p class="history-empty">${escapeHtml(String(error))}</p>`;
+  } finally {
+    elements.historyList.removeAttribute("aria-busy");
+  }
+}
+
+function renderHistory() {
+  const count = state.conversions.length;
+  elements.historySummary.textContent = count === 0
+    ? "Completed conversions will appear here."
+    : `${count} saved ${count === 1 ? "conversion" : "conversions"}, newest first.`;
+  elements.historyButton.title = count === 0 ? "No saved conversions" : `${count} saved conversions`;
+  if (count === 0) {
+    elements.historyList.innerHTML = `
+      <div class="history-empty">
+        <strong>No conversions yet</strong>
+        <span>Choose a file to create your first local PDF.</span>
+      </div>
+    `;
+    return;
+  }
+  elements.historyList.innerHTML = state.conversions.map(historyEntryHtml).join("");
+}
+
+function historyEntryHtml(conversion) {
+  const finished = conversion.status === "finished";
+  const missingMessage = finished && conversion.missing
+    ? conversion.restorable || conversion.reconvertible
+      ? "The saved PDF is missing. Choose an available recovery option."
+      : "The saved PDF is missing, and the original source is unavailable."
+    : "";
+  const detail = conversion.error && !finished
+    ? conversion.error
+    : conversion.outputPath || conversion.sourcePath || "No file path is available.";
+  const actions = [];
+  if (finished && !conversion.missing) {
+    actions.push(historyButtonHtml("open", conversion.id, "Open PDF", "primary"));
+  }
+  if (conversion.missing && conversion.restorable) {
+    actions.push(historyButtonHtml("restore", conversion.id, "Restore saved copy", "primary"));
+  }
+  if (conversion.missing && conversion.reconvertible) {
+    actions.push(historyButtonHtml("reconvert", conversion.id, "Reconvert", "primary"));
+  }
+  actions.push(historyButtonHtml("delete", conversion.id, "Delete", "danger"));
+  return `
+    <article class="history-entry" data-status="${escapeHtml(conversion.status)}">
+      <header>
+        <div>
+          <h4 title="${escapeHtml(conversion.sourceName)}">${escapeHtml(conversion.sourceName)}</h4>
+          <p>${escapeHtml(formatHistoryMeta(conversion))}</p>
+        </div>
+        <span class="history-status">${escapeHtml(titleCase(conversion.status))}</span>
+      </header>
+      ${missingMessage ? `<p class="history-warning">${escapeHtml(missingMessage)}</p>` : ""}
+      <p class="history-detail" title="${escapeHtml(detail)}">${escapeHtml(detail)}</p>
+      <div class="history-actions">${actions.join("")}</div>
+    </article>
+  `;
+}
+
+function historyButtonHtml(action, id, label, kind) {
+  return `<button type="button" class="history-action ${kind}" data-history-action="${action}" data-conversion-id="${id}">${label}</button>`;
+}
+
+async function handleHistoryAction(event) {
+  const button = event.target.closest("[data-history-action]");
+  if (!button) return;
+  const conversion = state.conversions.find((entry) => entry.id === button.dataset.conversionId);
+  if (!conversion) return;
+  const action = button.dataset.historyAction;
+  if (action === "delete" && !confirm(`Delete the history entry for ${conversion.sourceName}? Its converted PDF will also be deleted if it still exists.`)) {
+    return;
+  }
+  button.disabled = true;
+  try {
+    if (action === "open") {
+      const availability = await invoke("open_conversion", { id: conversion.id });
+      Object.assign(conversion, availability);
+      if (availability.missing) {
+        renderHistory();
+        showStatus("The converted PDF is missing. Choose an available recovery option in History.", "error");
+      }
+    } else if (action === "restore") {
+      await invoke("restore_conversion", { id: conversion.id });
+      showStatus(`${conversion.sourceName} was restored from its legacy saved copy.`, "success");
+      await loadHistory();
+    } else if (action === "reconvert") {
+      elements.historyDialog.close();
+      await beginConversion(() => invoke("reconvert", { id: conversion.id }));
+    } else if (action === "delete") {
+      await invoke("delete_conversion", { id: conversion.id });
+      showStatus(`Removed ${conversion.sourceName} from conversion history.`, "success");
+      await loadHistory();
+    }
+  } catch (error) {
+    showStatus(String(error), "error");
+    await loadHistory();
+  } finally {
+    if (button.isConnected) button.disabled = false;
+  }
+}
+
+function formatHistoryMeta(conversion) {
+  const format = conversion.detectedFormat ? conversion.detectedFormat.toUpperCase() : "Unknown";
+  return `${format} → PDF · ${formatDate(conversion.createdAt)}`;
+}
+
+function formatDate(value) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Unknown date";
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
 }
 
 function setBusy(busy) {
@@ -251,4 +383,4 @@ function escapeHtml(value) {
   })[character]);
 }
 
-await loadSupportedFormats();
+await Promise.all([loadSupportedFormats(), loadHistory()]);

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { open } from "@tauri-apps/plugin-dialog";
 import { WorkerBrowserConverter, createWasmPaths } from "@matbee/libreoffice-converter/browser";
+import { ConversionGuard } from "./conversion-guard.js";
 
 const state = {
   selectedPath: null,
@@ -55,6 +56,7 @@ class LibreOfficeWasmRunner {
 }
 
 const wasmRunner = new LibreOfficeWasmRunner();
+const conversionGuard = new ConversionGuard();
 
 elements.chooseFile.addEventListener("click", chooseFile);
 elements.convert.addEventListener("submit", async (event) => {
@@ -108,6 +110,11 @@ async function chooseFile() {
 }
 
 async function beginConversion(createStart) {
+  const token = conversionGuard.begin();
+  if (!token) {
+    showStatus("Another conversion is already running. Wait for it to finish or cancel it.", "error");
+    return;
+  }
   setBusy(true);
   state.cancellationRequested = false;
   showStatus("Preparing local conversion…", "working");
@@ -138,9 +145,11 @@ async function beginConversion(createStart) {
   } catch (error) {
     if (!state.cancellationRequested) showStatus(String(error), "error");
   } finally {
-    state.activeConversionId = null;
-    state.cancellationRequested = false;
-    setBusy(false);
+    if (conversionGuard.finish(token)) {
+      state.activeConversionId = null;
+      state.cancellationRequested = false;
+      setBusy(false);
+    }
     await loadHistory();
   }
 }
@@ -228,6 +237,7 @@ function renderHistory() {
 
 function historyEntryHtml(conversion) {
   const finished = conversion.status === "finished";
+  const terminal = ["finished", "failed", "cancelled"].includes(conversion.status);
   const missingMessage = finished && conversion.missing
     ? conversion.restorable || conversion.reconvertible
       ? "The saved PDF is missing. Choose an available recovery option."
@@ -244,9 +254,11 @@ function historyEntryHtml(conversion) {
     actions.push(historyButtonHtml("restore", conversion.id, "Restore saved copy", "primary"));
   }
   if (conversion.missing && conversion.reconvertible) {
-    actions.push(historyButtonHtml("reconvert", conversion.id, "Reconvert", "primary"));
+    actions.push(historyButtonHtml("reconvert", conversion.id, "Reconvert", "primary", conversionGuard.isActive));
   }
-  actions.push(historyButtonHtml("delete", conversion.id, "Delete", "danger"));
+  if (terminal) {
+    actions.push(historyButtonHtml("delete", conversion.id, "Delete", "danger"));
+  }
   return `
     <article class="history-entry" data-status="${escapeHtml(conversion.status)}">
       <header>
@@ -263,8 +275,8 @@ function historyEntryHtml(conversion) {
   `;
 }
 
-function historyButtonHtml(action, id, label, kind) {
-  return `<button type="button" class="history-action ${kind}" data-history-action="${action}" data-conversion-id="${id}">${label}</button>`;
+function historyButtonHtml(action, id, label, kind, disabled = false) {
+  return `<button type="button" class="history-action ${kind}" data-history-action="${action}" data-conversion-id="${id}"${disabled ? " disabled" : ""}>${label}</button>`;
 }
 
 async function handleHistoryAction(event) {
@@ -273,6 +285,10 @@ async function handleHistoryAction(event) {
   const conversion = state.conversions.find((entry) => entry.id === button.dataset.conversionId);
   if (!conversion) return;
   const action = button.dataset.historyAction;
+  if (action === "reconvert" && conversionGuard.isActive) {
+    showStatus("Another conversion is already running. Wait for it to finish or cancel it.", "error");
+    return;
+  }
   if (action === "delete" && !confirm(`Delete the history entry for ${conversion.sourceName}? Its converted PDF will also be deleted if it still exists.`)) {
     return;
   }
@@ -321,6 +337,9 @@ function formatDate(value) {
 
 function setBusy(busy) {
   elements.chooseFile.disabled = busy;
+  elements.historyList.querySelectorAll('[data-history-action="reconvert"]').forEach((button) => {
+    button.disabled = busy;
+  });
   if (busy && state.activeConversionId) {
     elements.convertButton.disabled = state.cancellationRequested;
     elements.convertButton.textContent = state.cancellationRequested ? "Cancelling…" : "Cancel";

--- a/src/styles.css
+++ b/src/styles.css
@@ -70,9 +70,11 @@ button:disabled {
     right: 0;
     display: flex;
     justify-content: flex-end;
+    gap: 10px;
     padding: 22px 26px;
 }
 
+#history-button,
 #settings-button {
     padding: 10px 18px;
     background: rgba(215, 190, 220, 0.82);
@@ -82,6 +84,7 @@ button:disabled {
     backdrop-filter: blur(8px);
 }
 
+#history-button:hover,
 #settings-button:hover {
     background: #c9a9d1;
     box-shadow: 0 8px 20px rgba(82, 55, 88, 0.14);
@@ -254,7 +257,8 @@ dialog::backdrop {
     backdrop-filter: blur(3px);
 }
 
-#settings-form {
+#settings-form,
+#history-panel {
     display: flex;
     flex-direction: column;
     gap: 14px;
@@ -262,17 +266,146 @@ dialog::backdrop {
     background: linear-gradient(145deg, #ffe6e8, #ffd3da);
 }
 
-#settings-form h3 {
+#settings-form h3,
+#history-panel h3 {
     margin: 0;
     text-align: center;
     font-size: 1.45rem;
 }
 
-#settings-form > p {
+#settings-form > p,
+#history-panel > p {
     margin: 0;
     color: var(--muted);
     text-align: center;
     line-height: 1.45;
+}
+
+#history-dialog {
+    width: min(680px, calc(100vw - 40px));
+}
+
+#history-list {
+    display: flex;
+    max-height: 55vh;
+    flex-direction: column;
+    gap: 10px;
+    overflow-y: auto;
+    padding: 2px;
+}
+
+#history-list[aria-busy="true"] {
+    opacity: 0.62;
+}
+
+.history-entry {
+    padding: 15px;
+    border: 1px solid rgba(91, 65, 94, 0.09);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.66);
+}
+
+.history-entry header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 14px;
+}
+
+.history-entry h4 {
+    max-width: 430px;
+    margin: 0;
+    overflow: hidden;
+    font-size: 1rem;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.history-entry header p,
+.history-detail,
+.history-warning {
+    margin: 5px 0 0;
+    color: var(--muted);
+    font-size: 0.8rem;
+    line-height: 1.4;
+}
+
+.history-status {
+    flex: 0 0 auto;
+    padding: 4px 8px;
+    border-radius: 999px;
+    background: var(--success);
+    color: #4a7556;
+    font-size: 0.7rem;
+    font-weight: 750;
+    text-transform: uppercase;
+}
+
+.history-entry[data-status="failed"] .history-status,
+.history-entry[data-status="cancelled"] .history-status {
+    background: var(--error);
+    color: #955656;
+}
+
+.history-warning {
+    padding: 8px 10px;
+    border-radius: 9px;
+    background: #fff1d8;
+    color: #805e2d;
+    font-weight: 600;
+}
+
+.history-detail {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.history-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.history-action {
+    padding: 8px 12px;
+    background: rgba(215, 190, 220, 0.72);
+    font-size: 0.78rem;
+    font-weight: 650;
+}
+
+.history-action.primary:hover:not(:disabled) {
+    background: #c9a9d1;
+}
+
+.history-action.danger {
+    margin-left: auto;
+    background: transparent;
+    color: #9a5555;
+}
+
+.history-action.danger:hover:not(:disabled) {
+    background: var(--error);
+}
+
+.history-empty {
+    display: flex;
+    min-height: 130px;
+    align-items: center;
+    justify-content: center;
+    flex-direction: column;
+    gap: 6px;
+    margin: 0;
+    padding: 24px;
+    border: 1px dashed rgba(91, 65, 94, 0.2);
+    border-radius: 14px;
+    color: var(--muted);
+    text-align: center;
+}
+
+.history-empty strong {
+    color: var(--ink);
 }
 
 #supported-list {
@@ -332,6 +465,9 @@ dialog::backdrop {
     #convert { padding: 20px; border-radius: 18px; }
     #file-selector { align-items: stretch; flex-direction: column; text-align: center; }
     #selected-file { padding: 4px 8px; }
+    .history-entry header { align-items: flex-start; flex-direction: column; gap: 8px; }
+    .history-entry h4 { max-width: calc(100vw - 100px); }
+    .history-action.danger { margin-left: 0; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/tests/conversion-guard.test.mjs
+++ b/tests/conversion-guard.test.mjs
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { ConversionGuard } from "../src/conversion-guard.js";
+
+test("a nested conversion cannot replace or clear the active conversion", () => {
+  const guard = new ConversionGuard();
+  const active = guard.begin();
+
+  assert.ok(active);
+  assert.equal(guard.isActive, true);
+  assert.equal(guard.begin(), null);
+  assert.equal(guard.finish(Symbol("other conversion")), false);
+  assert.equal(guard.isActive, true);
+  assert.equal(guard.finish(active), true);
+  assert.equal(guard.isActive, false);
+});


### PR DESCRIPTION
## Summary

- bump File Converter to 1.0.1
- upgrade checkout and setup-node to their Node 24-based action runtimes
- expose output availability and recovery metadata from the Rust history command
- add a compact History dialog for opening, restoring, reconverting, and deleting entries
- prevent active conversions from being deleted or replaced by nested reconversions
- isolate LibreOffice fixtures in separate processes with a hard timeout so CI fails promptly instead of hanging
- keep the existing converter design without restoring the removed search page

## Commits

1. `chore: prepare 1.0.1 CI runtime`
2. `feat: expose history recovery availability`
3. `feat: restore conversion history controls`
4. `fix: protect active conversion state`
5. `test: isolate LibreOffice smoke processes`

## Validation

- `npm run build`
- `npm run test:frontend` — 1 passed
- `npm run test:libreoffice` — DOCX, PPTX, XLSX, ODT, RTF, and TXT passed
- `cargo check --workspace --all-targets --locked`
- `cargo test --workspace --locked` — 19 passed
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`

Closes #22
Closes #24
Closes #25
